### PR TITLE
Use fake time in counter tests

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -6,7 +6,25 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 )
+
+// package initialization code
+// sets up a ticker to "cache" time
+
+const jiffy = 100
+
+var ticks int64
+var ticker = time.NewTicker(time.Millisecond * jiffy)
+
+func init() {
+	start := time.Now().UnixNano()
+	go func() {
+		for t := range ticker.C {
+			atomic.StoreInt64(&ticks, t.UnixNano()-start)
+		}
+	}()
+}
 
 // Counter represents an always incrementing metric type
 // Counter differs from BasicCounter by having additional

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -6,24 +6,8 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
-
-// package initialization code
-// sets up a ticker to "cache" time
-
-var ticks int64
-
-func init() {
-	start := time.Now().UnixNano()
-	ticker := time.NewTicker(time.Millisecond * jiffy)
-	go func() {
-		for t := range ticker.C {
-			atomic.StoreInt64(&ticks, t.UnixNano()-start)
-		}
-	}()
-}
 
 // OutputFilterFunc represents a function that is used to filter
 // metrics from being reported out from JSON handler
@@ -46,8 +30,6 @@ type MetricContext struct {
 // in-memory
 // Arguments:
 // namespace - namespace that all metrics in this context belong to
-
-const jiffy = 100
 
 //nanoseconds in a second represented in float64
 const NsInSec = float64(time.Second)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -2,33 +2,36 @@
 
 package metrics
 
-import "testing"
-import "time"
-import "math"
-import "sync"
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
-// BUG: This test will most likely fail on a highly loaded
-// system
+func init() {
+	// Stop the global ticker used by counters to measure time. This forces time to be
+	// advanced manually, making tests deterministic as long as they are sequential.
+	ticker.Stop()
+}
+
+// advanceCounterTime advances counters' global clock by the given duration. Use this in
+// unit tests to simulate the passage of time where you might be tempted to call
+// time.Sleep().
+func advanceCounterTime(t time.Duration) {
+	atomic.AddInt64(&ticks, t.Nanoseconds())
+}
+
 func TestCounterRate(t *testing.T) {
 	c := NewCounter()
-	// increment counter every 10ms in two goroutines
+	// simulate incrementing the counter every 10ms in two goroutines
 	// rate ~ 200/sec
-	tick1 := time.NewTicker(time.Millisecond * 10)
-	go func() {
-		for _ = range tick1.C {
-			c.Add(1)
-		}
-	}()
-	tick2 := time.NewTicker(time.Millisecond * 10)
-	go func() {
-		for _ = range tick2.C {
-			c.Add(1)
-		}
-	}()
-
-	time.Sleep(time.Millisecond * 1000)
-	tick1.Stop()
-	tick2.Stop()
+	for i := 0; i < 100; i++ {
+		advanceCounterTime(time.Millisecond * 10)
+		c.Add(1)
+		c.Add(1)
+	}
 
 	want := 200.0
 	out := c.ComputeRate()
@@ -41,7 +44,7 @@ func TestCounterRate(t *testing.T) {
 func TestCounterRateNoChange(t *testing.T) {
 	c := NewCounter()
 	c.Set(0)
-	time.Sleep(time.Millisecond * 100)
+	advanceCounterTime(time.Millisecond * 100)
 	c.Set(0)
 	want := 0.0
 	out := c.ComputeRate()
@@ -53,7 +56,7 @@ func TestCounterRateNoChange(t *testing.T) {
 func TestCounterRateOverflow(t *testing.T) {
 	c := NewCounter()
 	c.Set(0)
-	time.Sleep(time.Millisecond * 100)
+	advanceCounterTime(time.Millisecond * 100)
 	c.Set(10)
 	want := c.ComputeRate()
 	t.Logf("Computed rate before reset %v", want)
@@ -65,10 +68,10 @@ func TestCounterRateOverflow(t *testing.T) {
 	if math.IsNaN(out) || (math.Abs(out-want) > math.SmallestNonzeroFloat64) {
 		t.Errorf("c.ComputeRate() = %v, want %v", out, want)
 	}
-	time.Sleep(time.Millisecond * 1000)
+	advanceCounterTime(time.Millisecond * 1000)
 	c.Set(1)
 	t.Logf("Counter state after set=1 %v", c)
-	time.Sleep(time.Millisecond * 1000)
+	advanceCounterTime(time.Millisecond * 1000)
 	c.Set(2)
 	t.Logf("Counter state after set=2 %v", c)
 	want = 1.0
@@ -129,7 +132,7 @@ func TestStatsTimer(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			stopWatch := s.Start()
-			time.Sleep(time.Millisecond * time.Duration(x) * 10)
+			time.Sleep(time.Millisecond * time.Duration(x) * 10) // timers use the system clock
 			s.Stop(stopWatch)
 		}()
 	}


### PR DESCRIPTION
Unit tests that depend on real time are prone to spurious failures, as
the success of a check often winds up depending on the current load of
the host running the tests. This seems to affect TestCounterRate
frequently.

This "fixes" the problem for counters, which use a cached timestamp that
is asynchronously updated. Now, for tests, asynchronous updates stop and
time is advanced at will. It's a messy solution, but it fixes the unit
test without any significant changes to the main package.