### PR TITLE
Add /health endpoint for checking health

### DIFF
--- a/cmd/inspect/main.go
+++ b/cmd/inspect/main.go
@@ -84,6 +84,7 @@ func main() {
 	// run http server
 	if servermode {
 		go func() {
+			http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {})
 			http.HandleFunc("/api/v1/metrics.json", m.HttpJsonHandler)
 			log.Fatal(http.ListenAndServe(address, nil))
 		}()


### PR DESCRIPTION
Adds a new HTTP endpoint for server mode, "/health", that always returns
a 200 response with an empty body. This is intended to be used as a
method for checking that the server is running without doing the work of
the main metrics reporting endpoint.